### PR TITLE
フッターのコピーライトを修正

### DIFF
--- a/src/components/organisms/layouts/Footer.tsx
+++ b/src/components/organisms/layouts/Footer.tsx
@@ -18,5 +18,8 @@ const StFooter = styled.footer`
   .copy {
     color: #868e96;
     font-size: 10px;
+    display: block;
+    text-align: center;
+    width: 100%;
   }
 `;


### PR DESCRIPTION
safariで見ると改行されていた点を修正